### PR TITLE
fix duplicate manifest, remove old xml api jar

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,9 @@ jobs:
         key: maven-cache
     - name: Setup CommandBox CLI
       uses: Ortus-Solutions/setup-commandbox@main
+      with:
+        # required for Lucee 7 support (cfconfig 2.7.7+)
+        installSystemModules: true
 
     - name: Install Dependencies
       run: box install

--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,7 @@
 						<!-- Empty imports, because most dependencies are inlined.-->
 						<Import-Package>javax.transaction.*</Import-Package>
 						<Private-Package>ortus.extension.orm</Private-Package>
-						<Require-Bundle>org.lucee.xml.apis;bundle-version=1.4.1</Require-Bundle>
-
+						
 						<!-- The extension version, used in ExtensionUtil -->
 						<Specification-Version>${project.version}</Specification-Version>
 
@@ -180,7 +179,7 @@ lucee-core-version: ${minLuceeVersion}
                      The best workaround appears to be not using those properties, and hardcoding a RELATIVE path
                      instead.-->
 							<toFile>target/META-INF/MANIFEST.MF</toFile>
-							<append>true</append>
+							<append>false</append>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
- remove old `org.lucee.xml.apis` from `Require-bundle` (tech debt, not needed anymore)
- fix duplicate entries in manifest problem

needed for this upcoming osgi fix! https://luceeserver.atlassian.net/browse/LDEV-6044

tmp GHA fix: forces a cfconfig update, so that lucee 7 will run