### PR TITLE
LDEV-3768 fix NPE on wrong-case HQL named parameters

### DIFF
--- a/extension/src/main/java/ortus/extension/orm/HibernateORMSession.java
+++ b/extension/src/main/java/ortus/extension/orm/HibernateORMSession.java
@@ -763,6 +763,9 @@ public class HibernateORMSession implements ORMSession {
 						if ( name == null )
 							continue; // param not needed will be ignored
 						type	= meta.getNamedParameterExpectedType( name );
+						if ( type == null )
+							throw ExceptionUtil.createException( this, null,
+							    "couldn't get type for ORM parameter [" + e.getKey() + "], entity names are case sensitive!", null );
 
 						obj		= HibernateCaster.toSQL( type, obj, isArray );
 						if ( isArray.toBooleanValue() ) {

--- a/tests/specs/luceeTests/tickets/LDEV3768.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV3768.cfc
@@ -1,0 +1,43 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function beforeAll(){
+		variables.uri = server.helpers.getTestPath( "tickets/LDEV3768" );
+	}
+
+	function run( testResults, testBox ){
+		describe( "Testcase for LDEV-3768", function(){
+			it( title="ORMExecuteQuery(), HQL with correct column name to declare param", body=function( currentSpec ){
+				local.result = _InternalRequest(
+					template : "#uri#/test.cfm",
+					forms : { Scene = 1 }
+				);
+				expect( trim( result.filecontent ) ).toBe( "true" );
+			});
+
+			it( title="ORMExecuteQuery(), HQL with wrong case column name without param", body=function( currentSpec ){
+				local.result = _InternalRequest(
+					template : "#uri#/test.cfm",
+					forms : { Scene = 2 }
+				);
+				expect( trim( result.filecontent ) ).toInclude( "Named parameter not bound" ); // it should throw
+			});
+
+			it( title="ORMExecuteQuery(), HQL with wrong case column name to declare param", body=function( currentSpec ){
+				local.result = _InternalRequest(
+					template : "#uri#/test.cfm",
+					forms : { Scene = 3 }
+				); // used to NPE
+				expect( trim( result.filecontent ) ).toInclude( "entity names are case sensitive" );
+			});
+
+			it( title="ORMExecuteQuery(), HQL with no params", body=function( currentSpec ){
+				local.result = _InternalRequest(
+					template : "#uri#/test.cfm",
+					forms : { Scene = 4 }
+				);
+				expect( trim( result.filecontent ) ).toBe( "true" );
+			});
+		});
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV3768/Application.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV3768/Application.cfc
@@ -1,0 +1,22 @@
+component {
+
+	this.name = "LDEV3768";
+
+	this.mappings[ "testsRoot" ]     = "/tests";
+	this.mappings[ "luceeTestRoot" ] = this.mappings[ "testsRoot" ] & "/specs/luceeTests";
+	server.helpers                   = new tests.specs.luceeTests.TestHelper();
+	this.datasources[ "testH2" ]     = server.helpers.getDatasource( "h2", expandPath( "db" ) );
+
+	this.ORMenabled = true;
+	this.ormSettings = {
+		datasource     = "testH2",
+		dbCreate       = "dropcreate",
+		useDBForMapping = false,
+		dialect         = "h2"
+	};
+
+	public function onRequestStart(){
+		setting requesttimeout=10;
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV3768/test.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV3768/test.cfc
@@ -1,0 +1,6 @@
+component persistent="true" table="test" {
+
+	property name="id" column="id" generator="increment";
+	property name="Ant" type="string";
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV3768/test.cfm
+++ b/tests/specs/luceeTests/tickets/LDEV3768/test.cfm
@@ -1,0 +1,22 @@
+<cfparam name="FORM.scene" default="">
+<cfscript>
+	try {
+		if ( form.scene == 1 ){
+			res = isArray( ORMExecuteQuery( "From test where Ant = :ok", { "ok": "lucee" } ) );
+			res = isArray( ORMExecuteQuery( hql="From test where Ant = :ok", params={ "ok": "lucee" } ) );
+		} else if ( form.scene == 2 ){
+			// no param checking at all, coz no params
+			res = isArray( ORMExecuteQuery( hql="From test where ant = :ok" ) );
+		} else if ( form.scene == 3 ){
+			// oh look, ant is lowercase, should be Ant
+			res = isArray( ORMExecuteQuery( hql="From test where ant = :ok", params={ "ok": "lucee" } ) );
+			res = isArray( ORMExecuteQuery( "From test where ant = :ok", { "ok": "lucee" } ) );
+		} else if ( form.scene == 4 ){
+			// no param checking at all, coz no params
+			res = isArray( ORMExecuteQuery( "From test where ant = 'lucee'" ) );
+		}
+	} catch ( any e ){
+		res = e.stacktrace;
+	}
+	writeoutput( res );
+</cfscript>


### PR DESCRIPTION
## Summary

- Add null check after `getNamedParameterExpectedType()` to throw a helpful "entity names are case sensitive" error instead of NPE
- Port test case from Lucee extension repo

## Reference

- Jira: [LDEV-3768](https://luceeserver.atlassian.net/browse/LDEV-3768)
- Already fixed in Lucee extension: `b885a05b7c2814b38777875f28f39fa85d6c79ce`

## Test plan

- [ ] Scene 1: correct case column name with param - should return `true`
- [ ] Scene 2: wrong case column name without param - should throw "Named parameter not bound"
- [ ] Scene 3: wrong case column name with param - should throw "entity names are case sensitive" (was NPE)
- [ ] Scene 4: no params - should return `true`