### PR TITLE
LDEV-3525 throw helpful error for missing .hbm.xml mapping file

### DIFF
--- a/extension/src/main/java/ortus/extension/orm/mapping/HBMCreator.java
+++ b/extension/src/main/java/ortus/extension/orm/mapping/HBMCreator.java
@@ -2123,8 +2123,9 @@ public class HBMCreator {
 	public static String loadMapping( Component cfc ) throws PageException, IOException {
 
 		Resource resource = getMappingResource( cfc );
-		if ( resource == null ) {
-			String message = String.format( "Hibernate mapping not found for entity [%s]", cfc.getName() );
+		if ( resource == null || !resource.exists() ) {
+			String message = String.format( "Hibernate mapping not found for entity [%s], missing xml file [%s]",
+			    cfc.getName(), resource != null ? resource.getAbsoluteResource() : "null" );
 			throw ExceptionUtil.createException( message );
 		}
 

--- a/tests/specs/luceeTests/tickets/LDEV3525.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV3525.cfc
@@ -1,0 +1,47 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function beforeAll(){
+		variables.uri = server.helpers.getTestPath( "tickets/LDEV3525" );
+		cleanup();
+	}
+
+	function afterAll(){
+		cleanup();
+	}
+
+	private function cleanup(){
+		var hbmFile = getDirectoryFromPath( getCurrentTemplatePath() ) & "LDEV3525/test.cfc.hbm.xml";
+		if ( fileExists( hbmFile ) ){
+			fileDelete( hbmFile );
+		}
+	}
+
+	function run( testResults, testBox ){
+		describe( "Testcase for LDEV-3525", function(){
+
+			it( "test autogenmap=false and missing xml mapping file", function(){
+				expect( function(){
+					local.result = _InternalRequest(
+						template : "#uri#/index.cfm",
+						url : {
+							autogenmap : false
+						}
+					);
+				}).toThrow( regex="Hibernate mapping not found for entity" );
+			});
+
+			it( "test autogenmap=true and missing xml mapping file", function(){
+				cleanup();
+				local.result = _InternalRequest(
+					template : "#uri#/index.cfm",
+					url : {
+						autogenmap : true
+					}
+				);
+				expect( result.fileContent.trim() ).toBe( "testing" );
+			});
+
+		});
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV3525/Application.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV3525/Application.cfc
@@ -1,0 +1,23 @@
+component displayname="Application" output="false" {
+
+	this.name = "autogenmap-missing-LDEV-3525-#url.autogenmap#";
+
+	this.mappings[ "testsRoot" ]     = "/tests";
+	this.mappings[ "luceeTestRoot" ] = this.mappings[ "testsRoot" ] & "/specs/luceeTests";
+	server.helpers                   = new tests.specs.luceeTests.TestHelper();
+	this.datasource                  = server.helpers.getDatasource( "h2", expandPath( "db" ) );
+
+	this.sessionManagement  = true;
+	this.setClientCookies   = true;
+	this.setDomainCookies   = false;
+	this.sessionTimeOut     = createTimeSpan( 0, 1, 0, 0 );
+	this.applicationTimeOut = createTimeSpan( 1, 0, 0, 0 );
+
+	this.ormenabled            = true;
+	this.ormSettings.savemapping = true;
+	this.ormSettings.autogenmap = url.autogenmap;
+
+	if ( url.autogenmap )
+		this.ormSettings.dbcreate = "dropcreate";
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV3525/Application.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV3525/Application.cfc
@@ -1,5 +1,6 @@
 component displayname="Application" output="false" {
 
+	param name="url.autogenmap" default="true";
 	this.name = "autogenmap-missing-LDEV-3525-#url.autogenmap#";
 
 	this.mappings[ "testsRoot" ]     = "/tests";

--- a/tests/specs/luceeTests/tickets/LDEV3525/index.cfm
+++ b/tests/specs/luceeTests/tickets/LDEV3525/index.cfm
@@ -1,0 +1,7 @@
+<cfscript>
+	test = new test();
+	test.setName( "Testing" );
+	entitySave( test );
+	result = entityLoadByPK( "test", 1 );
+	echo( result.getName() );
+</cfscript>

--- a/tests/specs/luceeTests/tickets/LDEV3525/test.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV3525/test.cfc
@@ -1,0 +1,8 @@
+component displayname="test" entityname="test" table="test" persistent=true output=false accessors=true {
+
+	property name="ID" ormtype="string" length="32" fieldtype="id" generator="uuid" unsavedvalue="" default="1";
+	property name="activeFlag" ormtype="boolean";
+	property name="urlTitle" ormtype="string";
+	property name="Name" ormtype="string";
+
+}


### PR DESCRIPTION
## Summary

- Add `!resource.exists()` check to `loadMapping()` so a missing `.hbm.xml` file throws a clear error instead of a raw `FileNotFoundException`
- Include the missing file path in the error message
- Port test case from Lucee extension repo

## Reference

- Jira [LDEV-3525](https://luceeserver.atlassian.net/browse/LDEV-3525)
- Already fixed in Lucee extension at `HBMCreator.java:1887-1888`

## Test plan

- [ ] `autogenmap=false` with no `.hbm.xml` file - should throw "Hibernate mapping not found for entity"
- [ ] `autogenmap=true` with no `.hbm.xml` file - should auto-generate and succeed