### PR TITLE
LDEV-4561 fire CFC entity events before global events

### DIFF
--- a/extension/src/main/java/ortus/extension/orm/event/EventListenerIntegrator.java
+++ b/extension/src/main/java/ortus/extension/orm/event/EventListenerIntegrator.java
@@ -159,8 +159,8 @@ public class EventListenerIntegrator
 		Struct		state			= entityStateToStruct( propertyNames, event.getState() );
 		Component	entityCFC		= CommonUtil.toComponent( event.getEntity(), null );
 
-		fireEventOnGlobalListener( EventListenerIntegrator.PRE_INSERT, event.getEntity(), event, state );
 		fireOnEntity( entityCFC, EventListenerIntegrator.PRE_INSERT, event, null );
+		fireEventOnGlobalListener( EventListenerIntegrator.PRE_INSERT, event.getEntity(), event, state );
 
 		// Convert state changes from CFML -> Java
 		Object[] stateValues = event.getState();
@@ -176,23 +176,23 @@ public class EventListenerIntegrator
 
 	@Override
 	public void onPostInsert( PostInsertEvent event ) {
-		fireEventOnGlobalListener( EventListenerIntegrator.POST_INSERT, event.getEntity(), event, null );
 		fireOnEntity( event.getEntity(), EventListenerIntegrator.POST_INSERT, event, null );
+		fireEventOnGlobalListener( EventListenerIntegrator.POST_INSERT, event.getEntity(), event, null );
 	}
 
 	// PreDeleteEventListener
 	@Override
 	public boolean onPreDelete( PreDeleteEvent event ) {
-		fireEventOnGlobalListener( EventListenerIntegrator.PRE_DELETE, event.getEntity(), event, null );
 		fireOnEntity( event.getEntity(), EventListenerIntegrator.PRE_DELETE, event, null );
+		fireEventOnGlobalListener( EventListenerIntegrator.PRE_DELETE, event.getEntity(), event, null );
 		return false;
 	}
 
 	// PostDeleteEventListener
 	@Override
 	public void onPostDelete( PostDeleteEvent event ) {
-		fireEventOnGlobalListener( EventListenerIntegrator.POST_DELETE, event.getEntity(), event, null );
 		fireOnEntity( event.getEntity(), EventListenerIntegrator.POST_DELETE, event, null );
+		fireEventOnGlobalListener( EventListenerIntegrator.POST_DELETE, event.getEntity(), event, null );
 	}
 
 	// PreUpdateEventListener
@@ -203,8 +203,8 @@ public class EventListenerIntegrator
 		Struct		oldState		= entityStateToStruct( propertyNames, event.getOldState() );
 		Component	entityCFC		= CommonUtil.toComponent( event.getEntity(), null );
 
-		fireEventOnGlobalListener( EventListenerIntegrator.PRE_UPDATE, event.getEntity(), event, oldState );
 		fireOnEntity( entityCFC, EventListenerIntegrator.PRE_UPDATE, event, oldState );
+		fireEventOnGlobalListener( EventListenerIntegrator.PRE_UPDATE, event.getEntity(), event, oldState );
 
 		// Convert state changes from CFML -> Java
 		Object[] stateValues = event.getState();
@@ -221,8 +221,8 @@ public class EventListenerIntegrator
 	// PostUpdateEventListener
 	@Override
 	public void onPostUpdate( PostUpdateEvent event ) {
-		fireEventOnGlobalListener( EventListenerIntegrator.POST_UPDATE, event.getEntity(), event, null );
 		fireOnEntity( event.getEntity(), EventListenerIntegrator.POST_UPDATE, event, null );
+		fireEventOnGlobalListener( EventListenerIntegrator.POST_UPDATE, event.getEntity(), event, null );
 	}
 
 	// PreLoadEventListener
@@ -235,8 +235,8 @@ public class EventListenerIntegrator
 	// PostLoadEventListener
 	@Override
 	public void onPostLoad( PostLoadEvent event ) {
-		fireEventOnGlobalListener( EventListenerIntegrator.POST_LOAD, event.getEntity(), event, null );
 		fireOnEntity( event.getEntity(), EventListenerIntegrator.POST_LOAD, event, null );
+		fireEventOnGlobalListener( EventListenerIntegrator.POST_LOAD, event.getEntity(), event, null );
 	}
 
 	@Override

--- a/tests/specs/luceeTests/tickets/LDEV4561.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV4561.cfc
@@ -1,0 +1,14 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	public void function testEventsTriggerOrder(){
+		local.uri = server.helpers.getTestPath( "tickets/LDEV4561/preInsert.cfm" );
+		local.result = _InternalRequest( uri );
+		expect( result.status ).toBe( 200 );
+		local.res = deserializeJson( result.fileContent );
+
+		expect( res.errors.len() ).toBe( 0, "errors #res.errors.toJson()#" );
+		expect( res.events.len() ).toBe( 2 );
+		expect( res.events ).toBe( [ "cfc_preInsert", "global_preInsert" ] );
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV4561/Application.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV4561/Application.cfc
@@ -1,0 +1,31 @@
+component {
+
+	this.name = "orm-events-order-LDEV4561";
+
+	this.mappings[ "testsRoot" ]     = "/tests";
+	this.mappings[ "luceeTestRoot" ] = this.mappings[ "testsRoot" ] & "/specs/luceeTests";
+	server.helpers                   = new tests.specs.luceeTests.TestHelper();
+	this.datasource                  = server.helpers.getDatasource( "h2", expandPath( "db" ) );
+
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate         : "dropcreate",
+		eventHandling    : true,
+		eventHandler     : "eventHandler",
+		autoManageSession : false,
+		flushAtRequestEnd : false,
+		useDBForMapping  : false,
+		dialect          : "h2"
+	};
+
+	function onApplicationStart(){
+		application.ormEventLog = [];
+	}
+
+	public function onRequestStart(){
+		setting requesttimeout=10;
+		application.ormEventLog = [];
+		application.ormEventErrorLog = [];
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV4561/Person.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV4561/Person.cfc
@@ -1,0 +1,15 @@
+component persistent="true" cfcName="person" {
+
+	property name="ID" type="numeric" ormtype="int" fieldtype="id" ormtype="long" generator="increment";
+	property name="Person" type="string";
+
+	public function preInsert(){
+		eventLog( arguments );
+	}
+
+	private function eventLog( required struct args ){
+		var eventName = CallStackGet( "array" )[ 2 ].function;
+		application.ormEventLog.append( "cfc_" & eventName );
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV4561/eventHandler.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV4561/eventHandler.cfc
@@ -1,0 +1,18 @@
+component hint="logs out any orm events" {
+
+	this.name = "global"; // used for logging out events
+
+	function init(){
+		return this;
+	}
+
+	function preInsert( entity, event ){
+		eventLog( arguments );
+	}
+
+	private function eventLog( required struct args ){
+		var eventName = CallStackGet( "array" )[ 2 ].function;
+		application.ormEventLog.append( "global_" & eventName );
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV4561/preInsert.cfm
+++ b/tests/specs/luceeTests/tickets/LDEV4561/preInsert.cfm
@@ -1,0 +1,25 @@
+<cfsetting showdebugoutput="false">
+<cfscript>
+	person = entityNew( "Person" );
+	person.setPerson( "ralio" );
+	entitySave( person );
+
+	ormFlush();
+	ormClearSession();
+
+	result = {
+		events : [],
+		errors : [],
+		person : entityLoadByPK( "Person", 1 ).getPerson()
+	};
+
+	loop array=application.ormEventLog item="a" {
+		arrayAppend( result.events, a );
+	};
+
+	loop array=application.ormEventErrorLog item="a" {
+		arrayAppend( result.errors, a );
+	};
+
+	echo( result.toJson() );
+</cfscript>


### PR DESCRIPTION
## Summary

- Swap event firing order so CFC entity listeners fire before global event handler
- Per Adobe docs, persistent CFC event handlers should be called before application-wide event handlers
- Port test case from Lucee extension repo

Before: `[global_preInsert, cfc_preInsert]`
After: `[cfc_preInsert, global_preInsert]`

Affected events: preInsert, postInsert, preDelete, postDelete, preUpdate, postUpdate, postLoad.

## Reference

- Jira: [LDEV-4561](https://luceeserver.atlassian.net/browse/LDEV-4561)
- Already fixed in Lucee extension: `10a027bb37648eeb459813e5b7d9ec94a0541269`

## Test plan

- [ ] Insert a Person entity with both CFC-level and global preInsert handlers
- [ ] Verify event log shows `["cfc_preInsert", "global_preInsert"]`