### PR TITLE
LDEV-6156 remove dead reconnect code, fix connection leak

### DIFF
--- a/extension/src/main/java/ortus/extension/orm/HibernateORMSession.java
+++ b/extension/src/main/java/ortus/extension/orm/HibernateORMSession.java
@@ -1,8 +1,6 @@
 package ortus.extension.orm;
 
 import java.io.Serializable;
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -40,7 +38,6 @@ import lucee.runtime.Component;
 import lucee.runtime.ComponentScope;
 import lucee.runtime.PageContext;
 import lucee.runtime.db.DataSource;
-import lucee.runtime.db.DatasourceConnection;
 import lucee.runtime.db.SQLItem;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.orm.ORMEngine;
@@ -75,7 +72,6 @@ public class HibernateORMSession implements ORMSession {
 	public class SessionAndConn {
 
 		private Session					s;
-		private DatasourceConnection	dc;
 		private final DataSource		d;
 		private SessionFactory			factory;
 		private final Logger			logger	= LoggerFactory.getLogger( SessionAndConn.class );
@@ -105,34 +101,16 @@ public class HibernateORMSession implements ORMSession {
 			return s;
 		}
 
-		public Connection getConnection( PageContext pc ) throws PageException {
-			try {
-				if ( dc == null || dc.isClosed() ) {
-					connect( pc );
-				}
-			} catch ( SQLException e ) {
-				throw ExceptionUtil.toPageException( e );
-			}
-			return dc.getConnection();
-		}
-
-		public void connect( PageContext pc ) throws PageException {
-			if ( dc != null )
-				CommonUtil.releaseDatasourceConnection( pc, dc, true );
-			dc = CommonUtil.getDatasourceConnection( pc, d, null, null, true );
-		}
-
 		public void close( PageContext pc ) throws PageException {
 			if ( logger.isDebugEnabled() )
 				logger.atDebug().log( "closing session" );
-			if ( s != null && s.isOpen() ) {
-				s.close();
-				s = null;
-			}
-
-			if ( dc != null ) {
-				CommonUtil.releaseDatasourceConnection( pc, dc, true );
-				dc = null;
+			try {
+				if ( s != null && s.isOpen() ) {
+					s.close();
+					s = null;
+				}
+			} catch ( Exception e ) {
+				logger.atError().log( "error closing session: {}", e.getMessage() );
 			}
 		}
 
@@ -206,26 +184,12 @@ public class HibernateORMSession implements ORMSession {
 			throw ExceptionUtil.createException( data, null, message, null );
 		}
 		Session s = sac.getSession( pc );
-		if ( !s.isOpen() || !s.isConnected() || isClosed( s ) ) {
-			if ( logger.isWarnEnabled() )
-				logger.atWarn().log( "session is open or not connected or closed; reconnecting" );
-			if ( pc == null )
-				pc = CFMLEngineFactory.getInstance().getThreadPageContext();
-
-			sac.connect( pc );
-			s.reconnect( sac.getConnection( pc ) );
-
+		if ( !s.isOpen() || !s.isConnected() ) {
+			// Session is broken — close and let getSession() open a fresh one
+			sac.close( pc );
+			sac.getSession( pc );
 		}
 		return sac;
-	}
-
-	/**
-	 * Check if the session is disconnected.
-	 *
-	 * @param s Hibernate session
-	 */
-	private boolean isClosed( Session s ) {
-		return !s.isConnected();
 	}
 
 	/**
@@ -898,10 +862,18 @@ public class HibernateORMSession implements ORMSession {
 	 */
 	@Override
 	public void closeAll( PageContext pc ) throws PageException {
+		PageException firstException = null;
 		for ( SessionAndConn sac : sessions.values() ) {
-			if ( sac.isOpen() )
-				sac.close( pc );
+			try {
+				if ( sac.isOpen() )
+					sac.close( pc );
+			} catch ( PageException e ) {
+				if ( firstException == null )
+					firstException = e;
+			}
 		}
+		if ( firstException != null )
+			throw firstException;
 	}
 
 	@Override

--- a/tests/specs/luceeTests/tickets/LDEV6129.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV6129.cfc
@@ -1,0 +1,54 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function beforeAll(){
+		variables.uri = server.helpers.getTestPath( "tickets/LDEV6129/basic" );
+		_InternalRequest( template: "#variables.uri#/setup.cfm" );
+	}
+
+	function run( testResults, testBox ){
+
+		describe( "LDEV-6129/6156 - ORM connection not released when flushAll() throws", function(){
+
+			it( title="connection returned to pool even when auto-flush throws a constraint violation", body=function( currentSpec ){
+
+				// Trigger the potential leak: unique constraint violation at request end
+				try {
+					_InternalRequest( template: "#variables.uri#/flush_leak.cfm" );
+				} catch ( any e ){
+					// flush error is expected
+					systemOutput( "flush_leak threw: #e.message#", true );
+				}
+
+				// Now verify the connection is actually usable
+				var N = 5;
+				for ( var i = 1; i <= N; i++ ){
+					var result = _InternalRequest( template: "#variables.uri#/simple.cfm" );
+					systemOutput( "simple request #i#: status=#result.status#, content=#trim( result.filecontent )#", true );
+					expect( result.status ).toBe( 200,
+						"simple request #i# failed — connection not available (pool exhausted?)" );
+					expect( left( trim( result.filecontent ), 2 ) ).toBe( "ok",
+						"simple request #i# returned unexpected content: #trim( result.filecontent )#" );
+				}
+
+			});
+
+		});
+
+		describe( "LDEV-6129/6156 - dead reconnect code throws when session.isConnected() returns false", function(){
+
+			it( title="entityLoad succeeds when session isConnected() is forced false via reflection", body=function( currentSpec ){
+
+				var result = _InternalRequest( template: "#variables.uri#/reconnect_leak.cfm" );
+				systemOutput( "reconnect_leak result: status=#result.status#, content=#trim( result.filecontent )#", true );
+
+				expect( result.status ).toBe( 200 );
+				expect( left( trim( result.filecontent ), 2 ) ).toBe( "ok",
+					"entityLoad failed after isConnected()=false — reconnect dead code is broken: #trim( result.filecontent )#" );
+
+			});
+
+		});
+
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV6129/basic/Application.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV6129/basic/Application.cfc
@@ -1,0 +1,25 @@
+component {
+
+	this.name = "LDEV-6129-basic";
+
+	this.datasources[ "LDEV6129h2" ] = {
+		class            : "org.h2.Driver",
+		bundleName       : "org.lucee.h2",
+		connectionString : "jdbc:h2:#expandPath( 'db/LDEV6129' )#;MODE=MySQL",
+		connectionLimit  : 1
+	};
+
+	this.ormEnabled = true;
+	this.datasource = "LDEV6129h2";
+	this.ormSettings = {
+		dbcreate          : "dropcreate",
+		dialect           : "h2",
+		flushAtRequestEnd : true,
+		autoManageSession : true
+	};
+
+	public function onRequestStart(){
+		setting requesttimeout=10;
+	}
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV6129/basic/LDEV6129Person.cfc
+++ b/tests/specs/luceeTests/tickets/LDEV6129/basic/LDEV6129Person.cfc
@@ -1,0 +1,6 @@
+component persistent="true" entityname="LDEV6129Person" {
+
+	property name="id"   fieldtype="id" type="numeric" ormtype="long" generator="increment";
+	property name="name" type="string" unique="true";
+
+}

--- a/tests/specs/luceeTests/tickets/LDEV6129/basic/flush_leak.cfm
+++ b/tests/specs/luceeTests/tickets/LDEV6129/basic/flush_leak.cfm
@@ -1,0 +1,25 @@
+<cfscript>
+	/*
+	 * LDEV-6129: trigger a connection leak by causing flushAll() to throw at request end.
+	 *
+	 * 1. entitySave(p1) + ormFlush() — commits "test" to DB
+	 * 2. entitySave(p2) with same unique name — no error yet (Hibernate doesn't query DB)
+	 * 3. Request ends: flushAtRequestEnd=true -> releaseORM() -> flushAll() throws unique violation
+	 *
+	 * BUG: flushAll() and closeAll() are in the same try block in PageContextImpl.releaseORM().
+	 * When flushAll() throws, closeAll() is skipped -> DatasourceConnection dc is never returned.
+	 */
+	uniqueName = createUUID();
+
+	p1 = entityNew( "LDEV6129Person" );
+	p1.setName( uniqueName );
+	entitySave( p1 );
+	ormFlush(); // commit p1 to DB — now uniqueName exists with a unique constraint
+
+	p2 = entityNew( "LDEV6129Person" );
+	p2.setName( uniqueName ); // same name — will collide at flush time
+	entitySave( p2 );
+	systemOutput( "flush_leak.cfm: entitySave(p2) done, request ending now — expect flush error", true );
+	// request ends here: auto-flush tries to INSERT p2, throws unique constraint violation
+	// closeAll() is skipped -> dc leaked
+</cfscript>

--- a/tests/specs/luceeTests/tickets/LDEV6129/basic/reconnect_leak.cfm
+++ b/tests/specs/luceeTests/tickets/LDEV6129/basic/reconnect_leak.cfm
@@ -1,0 +1,66 @@
+<cfscript>
+	/*
+	 * LDEV-6156: reproduce the dead reconnect code bug in HibernateORMSession.getSessionAndConn().
+	 *
+	 * The condition `!s.isConnected()` can fire under load (e.g. MySQL 9.5, pool pressure).
+	 * When it does, the current code calls:
+	 *   sac.connect(pc)          -- acquires DatasourceConnection dc from pool
+	 *   s.reconnect(conn)        -- ALWAYS throws IllegalStateException on Hibernate 5.6
+	 *                               factory-opened sessions; dc is leaked
+	 *
+	 * We force isConnected() = false via reflection on the Hibernate internals, then
+	 * call entityLoad() to trigger the path.
+	 *
+	 * Expected output before fix: ERROR: ... Cannot manually reconnect ...
+	 * Expected output after fix:  ok
+	 */
+
+	// 1. Load any entity to ensure the session + connection are open
+	entityLoad( "LDEV6129Person" );
+
+	// 2. Get the raw Hibernate SessionImpl
+	hibSession = ormGetSession();
+
+	// 3. Walk the class hierarchy to find the private jdbcCoordinator field
+	coordField = javaCast( "null", "" );
+	klass = hibSession.getClass();
+	while ( !isNull( klass ) ) {
+		try {
+			coordField = klass.getDeclaredField( "jdbcCoordinator" );
+			break;
+		}
+		catch ( any e ) {
+			klass = klass.getSuperclass();
+		}
+	}
+
+	if ( isNull( coordField ) ) {
+		writeOutput( "SKIP: jdbcCoordinator field not found" );
+		return;
+	}
+
+	coordField.setAccessible( true );
+	jdbcCoord = coordField.get( hibSession );
+
+	// 4. Get logicalConnection from JdbcCoordinatorImpl
+	logConnField = jdbcCoord.getClass().getDeclaredField( "logicalConnection" );
+	logConnField.setAccessible( true );
+	logConn = logConnField.get( jdbcCoord );
+
+	// 5. Force closed = true -> isConnected() now returns false
+	closedField = logConn.getClass().getDeclaredField( "closed" );
+	closedField.setAccessible( true );
+	closedField.set( logConn, javaCast( "boolean", true ) );
+
+	// 6. Trigger getSessionAndConn() — enters reconnect path because isConnected() == false
+	//    Before fix: throws IllegalStateException (s.reconnect() always throws on managed sessions)
+	//    After fix:  broken session closed, fresh session opened, entityLoad succeeds
+	try {
+		entityLoad( "LDEV6129Person" );
+		writeOutput( "ok" );
+	}
+	catch ( any e ) {
+		writeOutput( "ERROR: #e.type# - #e.message#" );
+		systemOutput( "reconnect_leak: caught exception: #e.type# - #e.message#", true );
+	}
+</cfscript>

--- a/tests/specs/luceeTests/tickets/LDEV6129/basic/setup.cfm
+++ b/tests/specs/luceeTests/tickets/LDEV6129/basic/setup.cfm
@@ -1,0 +1,3 @@
+<cfscript>
+	ormReload();
+</cfscript>

--- a/tests/specs/luceeTests/tickets/LDEV6129/basic/simple.cfm
+++ b/tests/specs/luceeTests/tickets/LDEV6129/basic/simple.cfm
@@ -1,0 +1,6 @@
+<cfscript>
+	// Simple ORM load — just proves we can get a connection from the pool.
+	// If a previous request leaked the only connection (maxTotal=1), this will throw.
+	result = entityLoad( "LDEV6129Person" );
+	writeOutput( "ok:#arrayLen( result )#" );
+</cfscript>


### PR DESCRIPTION
## Summary

- Remove dead `SessionAndConn.dc` field, `connect()`, `getConnection()` — held an idle JDBC connection per session since Hibernate 3, unused since `ConnectionProviderImpl` was introduced in 2016
- Remove dead `s.reconnect()` block from `getSessionAndConn()` — always throws `IllegalStateException` on Hibernate 5.6 factory-opened sessions
- Replace with session recovery: if session is broken (not open or not connected), close it and open a fresh one
- Add try-catch to `SessionAndConn.close()` so session close errors don't prevent cleanup
- Make `closeAll()` robust — catch exceptions per session so one failure doesn't skip the rest
- Remove redundant `isClosed()` method (duplicated `!isConnected()` check)

## Reference

- Jira: [LDEV-6156](https://luceeserver.atlassian.net/browse/LDEV-6156)
- Related: [LDEV-6129](https://luceeserver.atlassian.net/browse/LDEV-6129) (original connection leak report)
- Analysis: [double-borrow.md](https://github.com/zspitzer/extension-hibernate/blob/patch/LDEV-6156/test-output/double-borrow.md) _(not in this repo, local notes)_

## Test approach

Two tests using H2 with `connectionLimit=1` so any leak is immediately visible:

- **flush_leak** — triggers unique constraint violation at request end, then proves the pool connection was returned via 5 subsequent entityLoad requests
- **reconnect_leak** — forces `isConnected()=false` via reflection, then calls entityLoad. Before fix: throws IllegalStateException. After fix: broken session recovered, entityLoad succeeds.

Test commit was pushed first without the fix to [confirm failures on CI](https://github.com/zspitzer/extension-hibernate/actions/runs/23227314524), then fix committed on top.

## Test plan

- [ ] reconnect_leak: entityLoad succeeds after forcing isConnected()=false
- [ ] flush_leak: connection returned to pool after constraint violation at request end
- [ ] Full existing test suite passes